### PR TITLE
Version 2.0.12 (2019-04-26)

### DIFF
--- a/dfp/Microchip.ATmega_DFP.pdsc
+++ b/dfp/Microchip.ATmega_DFP.pdsc
@@ -5,6 +5,7 @@
    <name>ATmega_DFP</name>
    <description>Microchip ATmega Series Device Support</description>
    <releases>
+      <release version="2.0.12" date="2019-04-26">Added missing registers and corrceted event generator list for mega4809/4808/3209/3208/1609/1608/809/808.</release>
       <release version="2.0.2" date="2019-01-24">Succeeds Atmel.ATmega_DFP 1.3.300.</release>
    </releases>
    <keywords>

--- a/dfp/atdf/ATmega1608.atdf
+++ b/dfp/atdf/ATmega1608.atdf
@@ -722,12 +722,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -950,6 +945,12 @@
         <register caption="OSC32K Control A" initval="0x00" name="OSC32KCTRLA" offset="0x18" rw="RW" size="1">
           <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
         </register>
+        <register caption="XOSC32K Control A" initval="0x00" name="XOSC32KCTRLA" offset="0x1C" rw="RW" size="1">
+          <bitfield caption="Crystal startup time" mask="0x30" name="CSUT" rw="RW" values="CLKCTRL_CSUT"/>
+          <bitfield caption="Enable" mask="0x1" name="ENABLE" rw="RW"/>
+          <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
+          <bitfield caption="Select" mask="0x4" name="SEL" rw="RW"/>
+        </register>
       </register-group>
       <value-group caption="clock select select" name="CLKCTRL_CLKSEL">
         <value caption="20MHz oscillator" name="OSC20M" value="0x00"/>
@@ -969,6 +970,12 @@
         <value caption="12X" name="12X" value="0x0A"/>
         <value caption="24X" name="24X" value="0x0B"/>
         <value caption="48X" name="48X" value="0x0C"/>
+      </value-group>
+      <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+        <value caption="1k cycles" name="1K" value="0x00"/>
+        <value caption="16k cycles" name="16K" value="0x01"/>
+        <value caption="32k cycles" name="32K" value="0x02"/>
+        <value caption="64k cycles" name="64K" value="0x03"/>
       </value-group>
     </module>
     <module caption="CPU" id="I2100" name="CPU">
@@ -1172,10 +1179,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1232,12 +1239,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1526,6 +1528,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega1609.atdf
+++ b/dfp/atdf/ATmega1609.atdf
@@ -457,8 +457,8 @@
         <interrupt index="4" module-instance="RTC" name="PIT"/>
         <interrupt index="5" module-instance="CCL" name="CCL"/>
         <interrupt index="6" module-instance="PORTA" name="PORT"/>
-        <interrupt index="7" module-instance="TCA0" name="OVF"/>
         <interrupt index="7" module-instance="TCA0" name="LUNF"/>
+        <interrupt index="7" module-instance="TCA0" name="OVF"/>
         <interrupt index="8" module-instance="TCA0" name="HUNF"/>
         <interrupt index="9" module-instance="TCA0" name="LCMP0"/>
         <interrupt index="9" module-instance="TCA0" name="CMP0"/>
@@ -743,12 +743,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -971,6 +966,12 @@
         <register caption="OSC32K Control A" initval="0x00" name="OSC32KCTRLA" offset="0x18" rw="RW" size="1">
           <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
         </register>
+        <register caption="XOSC32K Control A" initval="0x00" name="XOSC32KCTRLA" offset="0x1C" rw="RW" size="1">
+          <bitfield caption="Crystal startup time" mask="0x30" name="CSUT" rw="RW" values="CLKCTRL_CSUT"/>
+          <bitfield caption="Enable" mask="0x1" name="ENABLE" rw="RW"/>
+          <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
+          <bitfield caption="Select" mask="0x4" name="SEL" rw="RW"/>
+        </register>
       </register-group>
       <value-group caption="clock select select" name="CLKCTRL_CLKSEL">
         <value caption="20MHz oscillator" name="OSC20M" value="0x00"/>
@@ -990,6 +991,12 @@
         <value caption="12X" name="12X" value="0x0A"/>
         <value caption="24X" name="24X" value="0x0B"/>
         <value caption="48X" name="48X" value="0x0C"/>
+      </value-group>
+      <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+        <value caption="1k cycles" name="1K" value="0x00"/>
+        <value caption="16k cycles" name="16K" value="0x01"/>
+        <value caption="32k cycles" name="32K" value="0x02"/>
+        <value caption="64k cycles" name="64K" value="0x03"/>
       </value-group>
     </module>
     <module caption="CPU" id="I2100" name="CPU">
@@ -1199,10 +1206,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1261,12 +1268,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1555,6 +1557,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega16M1.atdf
+++ b/dfp/atdf/ATmega16M1.atdf
@@ -1008,7 +1008,7 @@
         <register caption="The ADC multiplexer Selection Register" name="ADMUX" offset="0x7C" size="1">
           <bitfield caption="Reference Selection Bits" mask="0xC0" name="REFS" values="ANALOG_ADC_V_REF2"/>
           <bitfield caption="Left Adjust Result" mask="0x20" name="ADLAR"/>
-          <bitfield caption="Analog Channel and Gain Selection Bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
+          <bitfield caption="ADC channel selection bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
         </register>
         <register caption="The ADC Control and Status register" name="ADCSRA" offset="0x7A" size="1" ocd-rw="R">
           <bitfield caption="ADC Enable" mask="0x80" name="ADEN"/>

--- a/dfp/atdf/ATmega3208.atdf
+++ b/dfp/atdf/ATmega3208.atdf
@@ -722,12 +722,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -1184,10 +1179,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1244,12 +1239,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1538,6 +1528,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega3209.atdf
+++ b/dfp/atdf/ATmega3209.atdf
@@ -743,12 +743,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -1211,10 +1206,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1273,12 +1268,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1567,6 +1557,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega32M1.atdf
+++ b/dfp/atdf/ATmega32M1.atdf
@@ -980,7 +980,7 @@
         <register caption="The ADC multiplexer Selection Register" name="ADMUX" offset="0x7C" size="1">
           <bitfield caption="Reference Selection Bits" mask="0xC0" name="REFS" values="ANALOG_ADC_V_REF2"/>
           <bitfield caption="Left Adjust Result" mask="0x20" name="ADLAR"/>
-          <bitfield caption="Analog Channel and Gain Selection Bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
+          <bitfield caption="ADC channel selection bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
         </register>
         <register caption="The ADC Control and Status register" name="ADCSRA" offset="0x7A" size="1" ocd-rw="R">
           <bitfield caption="ADC Enable" mask="0x80" name="ADEN"/>

--- a/dfp/atdf/ATmega4808.atdf
+++ b/dfp/atdf/ATmega4808.atdf
@@ -440,15 +440,15 @@
         <interrupt index="4" module-instance="RTC" name="PIT"/>
         <interrupt index="5" module-instance="CCL" name="CCL"/>
         <interrupt index="6" module-instance="PORTA" name="PORT"/>
-        <interrupt index="7" module-instance="TCA0" name="OVF"/>
         <interrupt index="7" module-instance="TCA0" name="LUNF"/>
+        <interrupt index="7" module-instance="TCA0" name="OVF"/>
         <interrupt index="8" module-instance="TCA0" name="HUNF"/>
         <interrupt index="9" module-instance="TCA0" name="LCMP0"/>
         <interrupt index="9" module-instance="TCA0" name="CMP0"/>
-        <interrupt index="10" module-instance="TCA0" name="CMP1"/>
         <interrupt index="10" module-instance="TCA0" name="LCMP1"/>
-        <interrupt index="11" module-instance="TCA0" name="LCMP2"/>
+        <interrupt index="10" module-instance="TCA0" name="CMP1"/>
         <interrupt index="11" module-instance="TCA0" name="CMP2"/>
+        <interrupt index="11" module-instance="TCA0" name="LCMP2"/>
         <interrupt index="12" module-instance="TCB0" name="INT"/>
         <interrupt index="13" module-instance="TCB1" name="INT"/>
         <interrupt index="14" module-instance="TWI0" name="TWIS"/>
@@ -722,12 +722,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -1184,10 +1179,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1244,12 +1239,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1538,6 +1528,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega4809.atdf
+++ b/dfp/atdf/ATmega4809.atdf
@@ -743,12 +743,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -1211,10 +1206,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1273,12 +1268,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1567,6 +1557,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega64M1.atdf
+++ b/dfp/atdf/ATmega64M1.atdf
@@ -980,7 +980,7 @@
         <register caption="The ADC multiplexer Selection Register" name="ADMUX" offset="0x7C" size="1">
           <bitfield caption="Reference Selection Bits" mask="0xC0" name="REFS" values="ANALOG_ADC_V_REF2"/>
           <bitfield caption="Left Adjust Result" mask="0x20" name="ADLAR"/>
-          <bitfield caption="Analog Channel and Gain Selection Bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
+          <bitfield caption="ADC channel selection bits" mask="0x1F" name="MUX" values="ANALOG_ADC_MUXPOS"/>
         </register>
         <register caption="The ADC Control and Status register" name="ADCSRA" offset="0x7A" size="1" ocd-rw="R">
           <bitfield caption="ADC Enable" mask="0x80" name="ADEN"/>

--- a/dfp/atdf/ATmega808.atdf
+++ b/dfp/atdf/ATmega808.atdf
@@ -440,8 +440,8 @@
         <interrupt index="4" module-instance="RTC" name="PIT"/>
         <interrupt index="5" module-instance="CCL" name="CCL"/>
         <interrupt index="6" module-instance="PORTA" name="PORT"/>
-        <interrupt index="7" module-instance="TCA0" name="LUNF"/>
         <interrupt index="7" module-instance="TCA0" name="OVF"/>
+        <interrupt index="7" module-instance="TCA0" name="LUNF"/>
         <interrupt index="8" module-instance="TCA0" name="HUNF"/>
         <interrupt index="9" module-instance="TCA0" name="LCMP0"/>
         <interrupt index="9" module-instance="TCA0" name="CMP0"/>
@@ -722,12 +722,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -950,6 +945,12 @@
         <register caption="OSC32K Control A" initval="0x00" name="OSC32KCTRLA" offset="0x18" rw="RW" size="1">
           <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
         </register>
+        <register caption="XOSC32K Control A" initval="0x00" name="XOSC32KCTRLA" offset="0x1C" rw="RW" size="1">
+          <bitfield caption="Crystal startup time" mask="0x30" name="CSUT" rw="RW" values="CLKCTRL_CSUT"/>
+          <bitfield caption="Enable" mask="0x1" name="ENABLE" rw="RW"/>
+          <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
+          <bitfield caption="Select" mask="0x4" name="SEL" rw="RW"/>
+        </register>
       </register-group>
       <value-group caption="clock select select" name="CLKCTRL_CLKSEL">
         <value caption="20MHz oscillator" name="OSC20M" value="0x00"/>
@@ -969,6 +970,12 @@
         <value caption="12X" name="12X" value="0x0A"/>
         <value caption="24X" name="24X" value="0x0B"/>
         <value caption="48X" name="48X" value="0x0C"/>
+      </value-group>
+      <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+        <value caption="1k cycles" name="1K" value="0x00"/>
+        <value caption="16k cycles" name="16K" value="0x01"/>
+        <value caption="32k cycles" name="32K" value="0x02"/>
+        <value caption="64k cycles" name="64K" value="0x03"/>
       </value-group>
     </module>
     <module caption="CPU" id="I2100" name="CPU">
@@ -1172,10 +1179,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1232,12 +1239,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1526,6 +1528,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/atdf/ATmega809.atdf
+++ b/dfp/atdf/ATmega809.atdf
@@ -464,8 +464,8 @@
         <interrupt index="9" module-instance="TCA0" name="CMP0"/>
         <interrupt index="10" module-instance="TCA0" name="CMP1"/>
         <interrupt index="10" module-instance="TCA0" name="LCMP1"/>
-        <interrupt index="11" module-instance="TCA0" name="CMP2"/>
         <interrupt index="11" module-instance="TCA0" name="LCMP2"/>
+        <interrupt index="11" module-instance="TCA0" name="CMP2"/>
         <interrupt index="12" module-instance="TCB0" name="INT"/>
         <interrupt index="13" module-instance="TCB1" name="INT"/>
         <interrupt index="14" module-instance="TWI0" name="TWIS"/>
@@ -743,12 +743,7 @@
       </value-group>
       <value-group caption="Bod level select" name="BOD_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="Configuration select" name="BOD_VLMCFG">
@@ -971,6 +966,12 @@
         <register caption="OSC32K Control A" initval="0x00" name="OSC32KCTRLA" offset="0x18" rw="RW" size="1">
           <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
         </register>
+        <register caption="XOSC32K Control A" initval="0x00" name="XOSC32KCTRLA" offset="0x1C" rw="RW" size="1">
+          <bitfield caption="Crystal startup time" mask="0x30" name="CSUT" rw="RW" values="CLKCTRL_CSUT"/>
+          <bitfield caption="Enable" mask="0x1" name="ENABLE" rw="RW"/>
+          <bitfield caption="Run standby" mask="0x2" name="RUNSTDBY" rw="RW"/>
+          <bitfield caption="Select" mask="0x4" name="SEL" rw="RW"/>
+        </register>
       </register-group>
       <value-group caption="clock select select" name="CLKCTRL_CLKSEL">
         <value caption="20MHz oscillator" name="OSC20M" value="0x00"/>
@@ -990,6 +991,12 @@
         <value caption="12X" name="12X" value="0x0A"/>
         <value caption="24X" name="24X" value="0x0B"/>
         <value caption="48X" name="48X" value="0x0C"/>
+      </value-group>
+      <value-group caption="Crystal startup time select" name="CLKCTRL_CSUT">
+        <value caption="1k cycles" name="1K" value="0x00"/>
+        <value caption="16k cycles" name="16K" value="0x01"/>
+        <value caption="32k cycles" name="32K" value="0x02"/>
+        <value caption="64k cycles" name="64K" value="0x03"/>
       </value-group>
     </module>
     <module caption="CPU" id="I2100" name="CPU">
@@ -1199,10 +1206,10 @@
         <value caption="Timer/Counter A0 compare 0" name="TCA0_CMP0" value="0x84"/>
         <value caption="Timer/Counter A0 compare 1" name="TCA0_CMP1" value="0x85"/>
         <value caption="Timer/Counter A0 compare 2" name="TCA0_CMP2" value="0x86"/>
-        <value caption="Timer/Counter B0 compare 0" name="TCB0_CMP0" value="0xA0"/>
-        <value caption="Timer/Counter B1 compare 0" name="TCB1_CMP0" value="0xA2"/>
-        <value caption="Timer/Counter B2 compare 0" name="TCB2_CMP0" value="0xA4"/>
-        <value caption="Timer/Counter B3 compare 0" name="TCB3_CMP0" value="0xA6"/>
+        <value caption="Timer/Counter B0 capture" name="TCB0_CAPT" value="0xA0"/>
+        <value caption="Timer/Counter B1 capture" name="TCB1_CAPT" value="0xA2"/>
+        <value caption="Timer/Counter B2 capture" name="TCB2_CAPT" value="0xA4"/>
+        <value caption="Timer/Counter B3 capture" name="TCB3_CAPT" value="0xA6"/>
       </value-group>
       <value-group caption="Software event on channels select" name="EVSYS_STROBE0">
         <value caption="" name="EV_STROBE_CH0" value="0x01"/>
@@ -1261,12 +1268,7 @@
       </value-group>
       <value-group caption="BOD Level select" name="FUSE_LVL">
         <value caption="1.8 V" name="BODLEVEL0" value="0x00"/>
-        <value caption="2.1 V" name="BODLEVEL1" value="0x01"/>
         <value caption="2.6 V" name="BODLEVEL2" value="0x02"/>
-        <value caption="2.9 V" name="BODLEVEL3" value="0x03"/>
-        <value caption="3.3 V" name="BODLEVEL4" value="0x04"/>
-        <value caption="3.7 V" name="BODLEVEL5" value="0x05"/>
-        <value caption="4.0 V" name="BODLEVEL6" value="0x06"/>
         <value caption="4.2 V" name="BODLEVEL7" value="0x07"/>
       </value-group>
       <value-group caption="BOD Sample Frequency select" name="FUSE_SAMPFREQ">
@@ -1555,6 +1557,7 @@
         <register caption="Compare" name="CMP" offset="0x0C" rw="RW" size="2"/>
         <register caption="Counter" name="CNT" offset="0x08" rw="RW" size="2"/>
         <register caption="Control A" initval="0x00" name="CTRLA" offset="0x00" rw="RW" size="1">
+          <bitfield caption="Correction enable" mask="0x4" name="CORREN" rw="RW"/>
           <bitfield caption="Prescaling Factor" mask="0x78" name="PRESCALER" rw="RW" values="RTC_PRESCALER"/>
           <bitfield caption="Enable" mask="0x1" name="RTCEN" rw="RW"/>
           <bitfield caption="Run In Standby" mask="0x80" name="RUNSTDBY" rw="RW"/>

--- a/dfp/avrasm/inc/m1284RFR2def.inc
+++ b/dfp/avrasm/inc/m1284RFR2def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m1284RFR2def.inc
 ;* Title             : Register/Bit Definitions for the ATmega1284RFR2
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega1284RFR2

--- a/dfp/avrasm/inc/m1608def.inc
+++ b/dfp/avrasm/inc/m1608def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m1608def.inc
 ;* Title             : Register/Bit Definitions for the ATmega1608
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega1608
@@ -128,6 +128,7 @@
 .equ CLKCTRL_OSC20MCALIBA = 0x0071       ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB = 0x0072       ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA = 0x0078        ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA = 0x007C       ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -928,6 +929,7 @@
 .equ CLKCTRL_OSC20MCALIBA_offset = 0x11  ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB_offset = 0x12  ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA_offset = 0x18   ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA_offset = 0x1C  ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -1725,12 +1727,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2086,6 +2083,19 @@
 ; CLKCTRL_OSC32KCTRLA masks
 ; Masks for CLKCTRL_RUNSTDBY already defined
 
+; CLKCTRL_XOSC32KCTRLA masks
+.equ CLKCTRL_CSUT_gm = 0x30              ; Crystal startup time group mask
+.equ CLKCTRL_CSUT_gp = 4                 ; Crystal startup time group position
+.equ CLKCTRL_CSUT0_bm = (1<<4)           ; Crystal startup time bit 0 mask
+.equ CLKCTRL_CSUT0_bp = 4                ; Crystal startup time bit 0 position
+.equ CLKCTRL_CSUT1_bm = (1<<5)           ; Crystal startup time bit 1 mask
+.equ CLKCTRL_CSUT1_bp = 5                ; Crystal startup time bit 1 position
+.equ CLKCTRL_ENABLE_bm = 0x01            ; Enable bit mask
+.equ CLKCTRL_ENABLE_bp = 0               ; Enable bit position
+; Masks for CLKCTRL_RUNSTDBY already defined
+.equ CLKCTRL_SEL_bm = 0x04               ; Select bit mask
+.equ CLKCTRL_SEL_bp = 2                  ; Select bit position
+
 ; clock select select
 .equ CLKCTRL_CLKSEL_OSC20M_gc = (0x00<<0) ; 20MHz oscillator
 .equ CLKCTRL_CLKSEL_OSCULP32K_gc = (0x01<<0) ; 32KHz oscillator
@@ -2104,6 +2114,12 @@
 .equ CLKCTRL_PDIV_12X_gc = (0x0A<<1)     ; 12X
 .equ CLKCTRL_PDIV_24X_gc = (0x0B<<1)     ; 24X
 .equ CLKCTRL_PDIV_48X_gc = (0x0C<<1)     ; 48X
+
+; Crystal startup time select
+.equ CLKCTRL_CSUT_1K_gc = (0x00<<4)      ; 1k cycles
+.equ CLKCTRL_CSUT_16K_gc = (0x01<<4)     ; 16k cycles
+.equ CLKCTRL_CSUT_32K_gc = (0x02<<4)     ; 32k cycles
+.equ CLKCTRL_CSUT_64K_gc = (0x03<<4)     ; 64k cycles
 
 
 ;*************************************************************************
@@ -2435,10 +2451,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2550,12 +2566,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -2971,6 +2982,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask

--- a/dfp/avrasm/inc/m1609def.inc
+++ b/dfp/avrasm/inc/m1609def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m1609def.inc
 ;* Title             : Register/Bit Definitions for the ATmega1609
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega1609
@@ -128,6 +128,7 @@
 .equ CLKCTRL_OSC20MCALIBA = 0x0071       ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB = 0x0072       ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA = 0x0078        ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA = 0x007C       ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -972,6 +973,7 @@
 .equ CLKCTRL_OSC20MCALIBA_offset = 0x11  ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB_offset = 0x12  ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA_offset = 0x18   ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA_offset = 0x1C  ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -1771,12 +1773,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2132,6 +2129,19 @@
 ; CLKCTRL_OSC32KCTRLA masks
 ; Masks for CLKCTRL_RUNSTDBY already defined
 
+; CLKCTRL_XOSC32KCTRLA masks
+.equ CLKCTRL_CSUT_gm = 0x30              ; Crystal startup time group mask
+.equ CLKCTRL_CSUT_gp = 4                 ; Crystal startup time group position
+.equ CLKCTRL_CSUT0_bm = (1<<4)           ; Crystal startup time bit 0 mask
+.equ CLKCTRL_CSUT0_bp = 4                ; Crystal startup time bit 0 position
+.equ CLKCTRL_CSUT1_bm = (1<<5)           ; Crystal startup time bit 1 mask
+.equ CLKCTRL_CSUT1_bp = 5                ; Crystal startup time bit 1 position
+.equ CLKCTRL_ENABLE_bm = 0x01            ; Enable bit mask
+.equ CLKCTRL_ENABLE_bp = 0               ; Enable bit position
+; Masks for CLKCTRL_RUNSTDBY already defined
+.equ CLKCTRL_SEL_bm = 0x04               ; Select bit mask
+.equ CLKCTRL_SEL_bp = 2                  ; Select bit position
+
 ; clock select select
 .equ CLKCTRL_CLKSEL_OSC20M_gc = (0x00<<0) ; 20MHz oscillator
 .equ CLKCTRL_CLKSEL_OSCULP32K_gc = (0x01<<0) ; 32KHz oscillator
@@ -2150,6 +2160,12 @@
 .equ CLKCTRL_PDIV_12X_gc = (0x0A<<1)     ; 12X
 .equ CLKCTRL_PDIV_24X_gc = (0x0B<<1)     ; 24X
 .equ CLKCTRL_PDIV_48X_gc = (0x0C<<1)     ; 48X
+
+; Crystal startup time select
+.equ CLKCTRL_CSUT_1K_gc = (0x00<<4)      ; 1k cycles
+.equ CLKCTRL_CSUT_16K_gc = (0x01<<4)     ; 16k cycles
+.equ CLKCTRL_CSUT_32K_gc = (0x02<<4)     ; 32k cycles
+.equ CLKCTRL_CSUT_64K_gc = (0x03<<4)     ; 64k cycles
 
 
 ;*************************************************************************
@@ -2487,10 +2503,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2604,12 +2620,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -3025,6 +3036,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask
@@ -4185,8 +4198,8 @@
 .equ PORTA_PORT_vect = 0x000C            ; 
 
 ; TCA0 interrupt vectors
-.equ TCA0_OVF_vect = 0x000E              ; 
 .equ TCA0_LUNF_vect = 0x000E             ; 
+.equ TCA0_OVF_vect = 0x000E              ; 
 .equ TCA0_HUNF_vect = 0x0010             ; 
 .equ TCA0_LCMP0_vect = 0x0012            ; 
 .equ TCA0_CMP0_vect = 0x0012             ; 
@@ -4314,8 +4327,8 @@
 
 ; TCA0 interrupt vector offsets
 
-.equ TCA0_OVF_voffset = 0
 .equ TCA0_LUNF_voffset = 0
+.equ TCA0_OVF_voffset = 0
 .equ TCA0_HUNF_voffset = 2
 .equ TCA0_LCMP0_voffset = 4
 .equ TCA0_CMP0_voffset = 4

--- a/dfp/avrasm/inc/m168PBdef.inc
+++ b/dfp/avrasm/inc/m168PBdef.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m168PBdef.inc
 ;* Title             : Register/Bit Definitions for the ATmega168PB
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega168PB

--- a/dfp/avrasm/inc/m2564RFR2def.inc
+++ b/dfp/avrasm/inc/m2564RFR2def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m2564RFR2def.inc
 ;* Title             : Register/Bit Definitions for the ATmega2564RFR2
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega2564RFR2

--- a/dfp/avrasm/inc/m3208def.inc
+++ b/dfp/avrasm/inc/m3208def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m3208def.inc
 ;* Title             : Register/Bit Definitions for the ATmega3208
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega3208
@@ -1727,12 +1727,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2456,10 +2451,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2571,12 +2566,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -2992,6 +2982,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask

--- a/dfp/avrasm/inc/m3209def.inc
+++ b/dfp/avrasm/inc/m3209def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m3209def.inc
 ;* Title             : Register/Bit Definitions for the ATmega3209
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega3209
@@ -1773,12 +1773,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2508,10 +2503,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2625,12 +2620,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -3046,6 +3036,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask

--- a/dfp/avrasm/inc/m324PBdef.inc
+++ b/dfp/avrasm/inc/m324PBdef.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m324PBdef.inc
 ;* Title             : Register/Bit Definitions for the ATmega324PB
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega324PB

--- a/dfp/avrasm/inc/m328PBdef.inc
+++ b/dfp/avrasm/inc/m328PBdef.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m328PBdef.inc
 ;* Title             : Register/Bit Definitions for the ATmega328PB
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega328PB

--- a/dfp/avrasm/inc/m4808def.inc
+++ b/dfp/avrasm/inc/m4808def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m4808def.inc
 ;* Title             : Register/Bit Definitions for the ATmega4808
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega4808
@@ -1727,12 +1727,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2456,10 +2451,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2571,12 +2566,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -2992,6 +2982,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask
@@ -4152,15 +4144,15 @@
 .equ PORTA_PORT_vect = 0x000C            ; 
 
 ; TCA0 interrupt vectors
-.equ TCA0_OVF_vect = 0x000E              ; 
 .equ TCA0_LUNF_vect = 0x000E             ; 
+.equ TCA0_OVF_vect = 0x000E              ; 
 .equ TCA0_HUNF_vect = 0x0010             ; 
 .equ TCA0_LCMP0_vect = 0x0012            ; 
 .equ TCA0_CMP0_vect = 0x0012             ; 
-.equ TCA0_CMP1_vect = 0x0014             ; 
 .equ TCA0_LCMP1_vect = 0x0014            ; 
-.equ TCA0_LCMP2_vect = 0x0016            ; 
+.equ TCA0_CMP1_vect = 0x0014             ; 
 .equ TCA0_CMP2_vect = 0x0016             ; 
+.equ TCA0_LCMP2_vect = 0x0016            ; 
 
 ; TCB0 interrupt vectors
 .equ TCB0_INT_vect = 0x0018              ; 
@@ -4271,15 +4263,15 @@
 
 ; TCA0 interrupt vector offsets
 
-.equ TCA0_OVF_voffset = 0
 .equ TCA0_LUNF_voffset = 0
+.equ TCA0_OVF_voffset = 0
 .equ TCA0_HUNF_voffset = 2
 .equ TCA0_LCMP0_voffset = 4
 .equ TCA0_CMP0_voffset = 4
-.equ TCA0_CMP1_voffset = 6
 .equ TCA0_LCMP1_voffset = 6
-.equ TCA0_LCMP2_voffset = 8
+.equ TCA0_CMP1_voffset = 6
 .equ TCA0_CMP2_voffset = 8
+.equ TCA0_LCMP2_voffset = 8
 
 ; TCB0 interrupt vector offsets
 

--- a/dfp/avrasm/inc/m4809def.inc
+++ b/dfp/avrasm/inc/m4809def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m4809def.inc
 ;* Title             : Register/Bit Definitions for the ATmega4809
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega4809
@@ -1773,12 +1773,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2508,10 +2503,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2625,12 +2620,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -3046,6 +3036,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask

--- a/dfp/avrasm/inc/m48PBdef.inc
+++ b/dfp/avrasm/inc/m48PBdef.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m48PBdef.inc
 ;* Title             : Register/Bit Definitions for the ATmega48PB
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega48PB

--- a/dfp/avrasm/inc/m644RFR2def.inc
+++ b/dfp/avrasm/inc/m644RFR2def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m644RFR2def.inc
 ;* Title             : Register/Bit Definitions for the ATmega644RFR2
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega644RFR2

--- a/dfp/avrasm/inc/m64HVE2def.inc
+++ b/dfp/avrasm/inc/m64HVE2def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m64HVE2def.inc
 ;* Title             : Register/Bit Definitions for the ATmega64HVE2
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega64HVE2

--- a/dfp/avrasm/inc/m808def.inc
+++ b/dfp/avrasm/inc/m808def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m808def.inc
 ;* Title             : Register/Bit Definitions for the ATmega808
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega808
@@ -128,6 +128,7 @@
 .equ CLKCTRL_OSC20MCALIBA = 0x0071       ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB = 0x0072       ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA = 0x0078        ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA = 0x007C       ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -928,6 +929,7 @@
 .equ CLKCTRL_OSC20MCALIBA_offset = 0x11  ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB_offset = 0x12  ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA_offset = 0x18   ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA_offset = 0x1C  ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -1725,12 +1727,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2086,6 +2083,19 @@
 ; CLKCTRL_OSC32KCTRLA masks
 ; Masks for CLKCTRL_RUNSTDBY already defined
 
+; CLKCTRL_XOSC32KCTRLA masks
+.equ CLKCTRL_CSUT_gm = 0x30              ; Crystal startup time group mask
+.equ CLKCTRL_CSUT_gp = 4                 ; Crystal startup time group position
+.equ CLKCTRL_CSUT0_bm = (1<<4)           ; Crystal startup time bit 0 mask
+.equ CLKCTRL_CSUT0_bp = 4                ; Crystal startup time bit 0 position
+.equ CLKCTRL_CSUT1_bm = (1<<5)           ; Crystal startup time bit 1 mask
+.equ CLKCTRL_CSUT1_bp = 5                ; Crystal startup time bit 1 position
+.equ CLKCTRL_ENABLE_bm = 0x01            ; Enable bit mask
+.equ CLKCTRL_ENABLE_bp = 0               ; Enable bit position
+; Masks for CLKCTRL_RUNSTDBY already defined
+.equ CLKCTRL_SEL_bm = 0x04               ; Select bit mask
+.equ CLKCTRL_SEL_bp = 2                  ; Select bit position
+
 ; clock select select
 .equ CLKCTRL_CLKSEL_OSC20M_gc = (0x00<<0) ; 20MHz oscillator
 .equ CLKCTRL_CLKSEL_OSCULP32K_gc = (0x01<<0) ; 32KHz oscillator
@@ -2104,6 +2114,12 @@
 .equ CLKCTRL_PDIV_12X_gc = (0x0A<<1)     ; 12X
 .equ CLKCTRL_PDIV_24X_gc = (0x0B<<1)     ; 24X
 .equ CLKCTRL_PDIV_48X_gc = (0x0C<<1)     ; 48X
+
+; Crystal startup time select
+.equ CLKCTRL_CSUT_1K_gc = (0x00<<4)      ; 1k cycles
+.equ CLKCTRL_CSUT_16K_gc = (0x01<<4)     ; 16k cycles
+.equ CLKCTRL_CSUT_32K_gc = (0x02<<4)     ; 32k cycles
+.equ CLKCTRL_CSUT_64K_gc = (0x03<<4)     ; 64k cycles
 
 
 ;*************************************************************************
@@ -2435,10 +2451,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2550,12 +2566,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -2971,6 +2982,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask
@@ -4131,8 +4144,8 @@
 .equ PORTA_PORT_vect = 0x0006            ; 
 
 ; TCA0 interrupt vectors
-.equ TCA0_LUNF_vect = 0x0007             ; 
 .equ TCA0_OVF_vect = 0x0007              ; 
+.equ TCA0_LUNF_vect = 0x0007             ; 
 .equ TCA0_HUNF_vect = 0x0008             ; 
 .equ TCA0_LCMP0_vect = 0x0009            ; 
 .equ TCA0_CMP0_vect = 0x0009             ; 
@@ -4250,8 +4263,8 @@
 
 ; TCA0 interrupt vector offsets
 
-.equ TCA0_LUNF_voffset = 0
 .equ TCA0_OVF_voffset = 0
+.equ TCA0_LUNF_voffset = 0
 .equ TCA0_HUNF_voffset = 1
 .equ TCA0_LCMP0_voffset = 2
 .equ TCA0_CMP0_voffset = 2

--- a/dfp/avrasm/inc/m809def.inc
+++ b/dfp/avrasm/inc/m809def.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m809def.inc
 ;* Title             : Register/Bit Definitions for the ATmega809
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega809
@@ -128,6 +128,7 @@
 .equ CLKCTRL_OSC20MCALIBA = 0x0071       ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB = 0x0072       ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA = 0x0078        ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA = 0x007C       ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -972,6 +973,7 @@
 .equ CLKCTRL_OSC20MCALIBA_offset = 0x11  ; OSC20M Calibration A
 .equ CLKCTRL_OSC20MCALIBB_offset = 0x12  ; OSC20M Calibration B
 .equ CLKCTRL_OSC32KCTRLA_offset = 0x18   ; OSC32K Control A
+.equ CLKCTRL_XOSC32KCTRLA_offset = 0x1C  ; XOSC32K Control A
 
 ;*************************************************************************
 ;** CPU - CPU
@@ -1771,12 +1773,7 @@
 
 ; Bod level select
 .equ BOD_LVL_BODLEVEL0_gc = (0x00<<0)    ; 1.8 V
-.equ BOD_LVL_BODLEVEL1_gc = (0x01<<0)    ; 2.1 V
 .equ BOD_LVL_BODLEVEL2_gc = (0x02<<0)    ; 2.6 V
-.equ BOD_LVL_BODLEVEL3_gc = (0x03<<0)    ; 2.9 V
-.equ BOD_LVL_BODLEVEL4_gc = (0x04<<0)    ; 3.3 V
-.equ BOD_LVL_BODLEVEL5_gc = (0x05<<0)    ; 3.7 V
-.equ BOD_LVL_BODLEVEL6_gc = (0x06<<0)    ; 4.0 V
 .equ BOD_LVL_BODLEVEL7_gc = (0x07<<0)    ; 4.2 V
 
 ; Configuration select
@@ -2132,6 +2129,19 @@
 ; CLKCTRL_OSC32KCTRLA masks
 ; Masks for CLKCTRL_RUNSTDBY already defined
 
+; CLKCTRL_XOSC32KCTRLA masks
+.equ CLKCTRL_CSUT_gm = 0x30              ; Crystal startup time group mask
+.equ CLKCTRL_CSUT_gp = 4                 ; Crystal startup time group position
+.equ CLKCTRL_CSUT0_bm = (1<<4)           ; Crystal startup time bit 0 mask
+.equ CLKCTRL_CSUT0_bp = 4                ; Crystal startup time bit 0 position
+.equ CLKCTRL_CSUT1_bm = (1<<5)           ; Crystal startup time bit 1 mask
+.equ CLKCTRL_CSUT1_bp = 5                ; Crystal startup time bit 1 position
+.equ CLKCTRL_ENABLE_bm = 0x01            ; Enable bit mask
+.equ CLKCTRL_ENABLE_bp = 0               ; Enable bit position
+; Masks for CLKCTRL_RUNSTDBY already defined
+.equ CLKCTRL_SEL_bm = 0x04               ; Select bit mask
+.equ CLKCTRL_SEL_bp = 2                  ; Select bit position
+
 ; clock select select
 .equ CLKCTRL_CLKSEL_OSC20M_gc = (0x00<<0) ; 20MHz oscillator
 .equ CLKCTRL_CLKSEL_OSCULP32K_gc = (0x01<<0) ; 32KHz oscillator
@@ -2150,6 +2160,12 @@
 .equ CLKCTRL_PDIV_12X_gc = (0x0A<<1)     ; 12X
 .equ CLKCTRL_PDIV_24X_gc = (0x0B<<1)     ; 24X
 .equ CLKCTRL_PDIV_48X_gc = (0x0C<<1)     ; 48X
+
+; Crystal startup time select
+.equ CLKCTRL_CSUT_1K_gc = (0x00<<4)      ; 1k cycles
+.equ CLKCTRL_CSUT_16K_gc = (0x01<<4)     ; 16k cycles
+.equ CLKCTRL_CSUT_32K_gc = (0x02<<4)     ; 32k cycles
+.equ CLKCTRL_CSUT_64K_gc = (0x03<<4)     ; 64k cycles
 
 
 ;*************************************************************************
@@ -2487,10 +2503,10 @@
 .equ EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0) ; Timer/Counter A0 compare 0
 .equ EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0) ; Timer/Counter A0 compare 1
 .equ EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0) ; Timer/Counter A0 compare 2
-.equ EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0) ; Timer/Counter B0 compare 0
-.equ EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0) ; Timer/Counter B1 compare 0
-.equ EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0) ; Timer/Counter B2 compare 0
-.equ EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0) ; Timer/Counter B3 compare 0
+.equ EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0) ; Timer/Counter B0 capture
+.equ EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0) ; Timer/Counter B1 capture
+.equ EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0) ; Timer/Counter B2 capture
+.equ EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0) ; Timer/Counter B3 capture
 
 ; Software event on channels select
 .equ EVSYS_STROBE0_EV_STROBE_CH0_gc = (0x01<<0) ; 
@@ -2604,12 +2620,7 @@
 
 ; BOD Level select
 .equ FUSE_LVL_BODLEVEL0_gc = (0x00<<5)   ; 1.8 V
-.equ FUSE_LVL_BODLEVEL1_gc = (0x01<<5)   ; 2.1 V
 .equ FUSE_LVL_BODLEVEL2_gc = (0x02<<5)   ; 2.6 V
-.equ FUSE_LVL_BODLEVEL3_gc = (0x03<<5)   ; 2.9 V
-.equ FUSE_LVL_BODLEVEL4_gc = (0x04<<5)   ; 3.3 V
-.equ FUSE_LVL_BODLEVEL5_gc = (0x05<<5)   ; 3.7 V
-.equ FUSE_LVL_BODLEVEL6_gc = (0x06<<5)   ; 4.0 V
 .equ FUSE_LVL_BODLEVEL7_gc = (0x07<<5)   ; 4.2 V
 
 ; BOD Sample Frequency select
@@ -3025,6 +3036,8 @@
 .equ RTC_CLKSEL1_bp = 1                  ; Clock Select bit 1 position
 
 ; RTC_CTRLA masks
+.equ RTC_CORREN_bm = 0x04                ; Correction enable bit mask
+.equ RTC_CORREN_bp = 2                   ; Correction enable bit position
 .equ RTC_PRESCALER_gm = 0x78             ; Prescaling Factor group mask
 .equ RTC_PRESCALER_gp = 3                ; Prescaling Factor group position
 .equ RTC_PRESCALER0_bm = (1<<3)          ; Prescaling Factor bit 0 mask
@@ -4192,8 +4205,8 @@
 .equ TCA0_CMP0_vect = 0x0009             ; 
 .equ TCA0_CMP1_vect = 0x000A             ; 
 .equ TCA0_LCMP1_vect = 0x000A            ; 
-.equ TCA0_CMP2_vect = 0x000B             ; 
 .equ TCA0_LCMP2_vect = 0x000B            ; 
+.equ TCA0_CMP2_vect = 0x000B             ; 
 
 ; TCB0 interrupt vectors
 .equ TCB0_INT_vect = 0x000C              ; 
@@ -4321,8 +4334,8 @@
 .equ TCA0_CMP0_voffset = 2
 .equ TCA0_CMP1_voffset = 3
 .equ TCA0_LCMP1_voffset = 3
-.equ TCA0_CMP2_voffset = 4
 .equ TCA0_LCMP2_voffset = 4
+.equ TCA0_CMP2_voffset = 4
 
 ; TCB0 interrupt vector offsets
 

--- a/dfp/avrasm/inc/m88PBdef.inc
+++ b/dfp/avrasm/inc/m88PBdef.inc
@@ -6,7 +6,7 @@
 ;* Number            : AVR000
 ;* File Name         : m88PBdef.inc
 ;* Title             : Register/Bit Definitions for the ATmega88PB
-;* Created           : 2019-01-24 03:51
+;* Created           : 2019-04-26 00:07
 ;* Version           : 1.00
 ;* Support e-mail    : avr@atmel.com
 ;* Target MCU        : ATmega88PB

--- a/dfp/edc/ATmega1608.PIC
+++ b/dfp/edc/ATmega1608.PIC
@@ -215,12 +215,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -283,7 +278,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3800" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3800" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -498,7 +493,24 @@
             </edc:SFRMode>
           </edc:SFRModeList>
         </edc:SFRDef>
-        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x7"/>
+        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x3"/>
+        <edc:SFRDef edc:_addr="0x7C" edc:access="--nn-nnn" edc:cname="XOSC32KCTRLA" edc:impl="0x37" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="CLKCTRL">
+          <edc:SFRModeList>
+            <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="CLKCTRL">
+              <edc:SFRFieldDef edc:cname="ENABLE" edc:desc="Enable" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="RUNSTDBY" edc:desc="Run standby" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="SEL" edc:desc="Select" edc:nzwidth="0x1"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CSUT" edc:desc="Crystal startup time" edc:nzwidth="0x2">
+                <edc:SFRFieldSemantic edc:cname="1K" edc:desc="1k cycles" edc:when="(field &amp; 0x3) == 0x00"/>
+                <edc:SFRFieldSemantic edc:cname="16K" edc:desc="16k cycles" edc:when="(field &amp; 0x3) == 0x01"/>
+                <edc:SFRFieldSemantic edc:cname="32K" edc:desc="32k cycles" edc:when="(field &amp; 0x3) == 0x02"/>
+                <edc:SFRFieldSemantic edc:cname="64K" edc:desc="64k cycles" edc:when="(field &amp; 0x3) == 0x03"/>
+              </edc:SFRFieldDef>
+            </edc:SFRMode>
+          </edc:SFRModeList>
+        </edc:SFRDef>
+        <edc:AdjustPoint edc:_addr="0x7D" edc:offset="0x3"/>
         <edc:SFRDef edc:_addr="0x80" edc:access="---nnnnn" edc:cname="CTRLA" edc:impl="0x1F" edc:mclr="00000101" edc:nzwidth="0x8" edc:por="00000101" ltx:memberofperipheral="BOD">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
@@ -525,12 +537,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -715,11 +722,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -916,10 +924,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -968,10 +976,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1020,10 +1028,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1072,10 +1080,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1124,10 +1132,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1176,10 +1184,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega1609.PIC
+++ b/dfp/edc/ATmega1609.PIC
@@ -40,8 +40,8 @@
     <edc:Interrupt edc:cname="PIT" edc:desc="" edc:irq="4" ltx:memberofperipheral="RTC"/>
     <edc:Interrupt edc:cname="CCL" edc:desc="" edc:irq="5" ltx:memberofperipheral="CCL"/>
     <edc:Interrupt edc:cname="PORT" edc:desc="" edc:irq="6" ltx:memberofperipheral="PORTA"/>
-    <edc:Interrupt edc:cname="OVF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LUNF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="OVF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="HUNF" edc:desc="" edc:irq="8" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="CMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
@@ -221,12 +221,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -289,7 +284,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3800" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3800" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -504,7 +499,24 @@
             </edc:SFRMode>
           </edc:SFRModeList>
         </edc:SFRDef>
-        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x7"/>
+        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x3"/>
+        <edc:SFRDef edc:_addr="0x7C" edc:access="--nn-nnn" edc:cname="XOSC32KCTRLA" edc:impl="0x37" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="CLKCTRL">
+          <edc:SFRModeList>
+            <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="CLKCTRL">
+              <edc:SFRFieldDef edc:cname="ENABLE" edc:desc="Enable" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="RUNSTDBY" edc:desc="Run standby" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="SEL" edc:desc="Select" edc:nzwidth="0x1"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CSUT" edc:desc="Crystal startup time" edc:nzwidth="0x2">
+                <edc:SFRFieldSemantic edc:cname="1K" edc:desc="1k cycles" edc:when="(field &amp; 0x3) == 0x00"/>
+                <edc:SFRFieldSemantic edc:cname="16K" edc:desc="16k cycles" edc:when="(field &amp; 0x3) == 0x01"/>
+                <edc:SFRFieldSemantic edc:cname="32K" edc:desc="32k cycles" edc:when="(field &amp; 0x3) == 0x02"/>
+                <edc:SFRFieldSemantic edc:cname="64K" edc:desc="64k cycles" edc:when="(field &amp; 0x3) == 0x03"/>
+              </edc:SFRFieldDef>
+            </edc:SFRMode>
+          </edc:SFRModeList>
+        </edc:SFRDef>
+        <edc:AdjustPoint edc:_addr="0x7D" edc:offset="0x3"/>
         <edc:SFRDef edc:_addr="0x80" edc:access="---nnnnn" edc:cname="CTRLA" edc:impl="0x1F" edc:mclr="00000101" edc:nzwidth="0x8" edc:por="00000101" ltx:memberofperipheral="BOD">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
@@ -531,12 +543,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -721,11 +728,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -922,10 +930,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -974,10 +982,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1026,10 +1034,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1078,10 +1086,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1130,10 +1138,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1182,10 +1190,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1234,10 +1242,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1286,10 +1294,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega16M1.PIC
+++ b/dfp/edc/ATmega16M1.PIC
@@ -670,7 +670,7 @@
         <edc:SFRDef edc:_addr="0x7C" edc:access="nnnnnnnn" edc:cname="ADMUX" edc:nzwidth="0x8" ltx:memberofperipheral="ADC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="ADC">
-              <edc:SFRFieldDef edc:cname="MUX" edc:desc="Analog Channel and Gain Selection Bits" edc:nzwidth="0x5">
+              <edc:SFRFieldDef edc:cname="MUX" edc:desc="ADC channel selection bits" edc:nzwidth="0x5">
                 <edc:SFRFieldSemantic edc:cname="ADC0" edc:desc="ADC input pin 0" edc:when="(field &amp; 0x1F) == 0x0"/>
                 <edc:SFRFieldSemantic edc:cname="ADC1" edc:desc="ADC input pin 1" edc:when="(field &amp; 0x1F) == 0x1"/>
                 <edc:SFRFieldSemantic edc:cname="ADC2" edc:desc="ADC input pin 2" edc:when="(field &amp; 0x1F) == 0x2"/>

--- a/dfp/edc/ATmega3208.PIC
+++ b/dfp/edc/ATmega3208.PIC
@@ -215,12 +215,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -283,7 +278,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3000" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3000" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -542,12 +537,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -732,11 +722,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -933,10 +924,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -985,10 +976,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1037,10 +1028,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1089,10 +1080,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1141,10 +1132,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1193,10 +1184,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega3209.PIC
+++ b/dfp/edc/ATmega3209.PIC
@@ -221,12 +221,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -289,7 +284,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3000" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3000" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -548,12 +543,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -738,11 +728,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -939,10 +930,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -991,10 +982,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1043,10 +1034,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1095,10 +1086,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1147,10 +1138,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1199,10 +1190,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1251,10 +1242,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1303,10 +1294,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega32M1.PIC
+++ b/dfp/edc/ATmega32M1.PIC
@@ -634,7 +634,7 @@
         <edc:SFRDef edc:_addr="0x7C" edc:access="nnnnnnnn" edc:cname="ADMUX" edc:nzwidth="0x8" ltx:memberofperipheral="ADC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="ADC">
-              <edc:SFRFieldDef edc:cname="MUX" edc:desc="Analog Channel and Gain Selection Bits" edc:nzwidth="0x5">
+              <edc:SFRFieldDef edc:cname="MUX" edc:desc="ADC channel selection bits" edc:nzwidth="0x5">
                 <edc:SFRFieldSemantic edc:cname="ADC0" edc:desc="ADC input pin 0" edc:when="(field &amp; 0x1F) == 0x0"/>
                 <edc:SFRFieldSemantic edc:cname="ADC1" edc:desc="ADC input pin 1" edc:when="(field &amp; 0x1F) == 0x1"/>
                 <edc:SFRFieldSemantic edc:cname="ADC2" edc:desc="ADC input pin 2" edc:when="(field &amp; 0x1F) == 0x2"/>

--- a/dfp/edc/ATmega4808.PIC
+++ b/dfp/edc/ATmega4808.PIC
@@ -40,15 +40,15 @@
     <edc:Interrupt edc:cname="PIT" edc:desc="" edc:irq="4" ltx:memberofperipheral="RTC"/>
     <edc:Interrupt edc:cname="CCL" edc:desc="" edc:irq="5" ltx:memberofperipheral="CCL"/>
     <edc:Interrupt edc:cname="PORT" edc:desc="" edc:irq="6" ltx:memberofperipheral="PORTA"/>
-    <edc:Interrupt edc:cname="OVF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LUNF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="OVF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="HUNF" edc:desc="" edc:irq="8" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="CMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
-    <edc:Interrupt edc:cname="CMP1" edc:desc="" edc:irq="10" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP1" edc:desc="" edc:irq="10" ltx:memberofperipheral="TCA0"/>
-    <edc:Interrupt edc:cname="LCMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="CMP1" edc:desc="" edc:irq="10" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="CMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="LCMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="INT" edc:desc="" edc:irq="12" ltx:memberofperipheral="TCB0"/>
     <edc:Interrupt edc:cname="INT" edc:desc="" edc:irq="13" ltx:memberofperipheral="TCB1"/>
     <edc:Interrupt edc:cname="TWIS" edc:desc="" edc:irq="14" ltx:memberofperipheral="TWI0"/>
@@ -215,12 +215,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -283,7 +278,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x2800" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x2800" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -542,12 +537,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -732,11 +722,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -933,10 +924,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -985,10 +976,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1037,10 +1028,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1089,10 +1080,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1141,10 +1132,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1193,10 +1184,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega4809.PIC
+++ b/dfp/edc/ATmega4809.PIC
@@ -221,12 +221,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -289,7 +284,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x2800" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x2800" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -548,12 +543,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -738,11 +728,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -939,10 +930,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -991,10 +982,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1043,10 +1034,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1095,10 +1086,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1147,10 +1138,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1199,10 +1190,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1251,10 +1242,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1303,10 +1294,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega64M1.PIC
+++ b/dfp/edc/ATmega64M1.PIC
@@ -634,7 +634,7 @@
         <edc:SFRDef edc:_addr="0x7C" edc:access="nnnnnnnn" edc:cname="ADMUX" edc:nzwidth="0x8" ltx:memberofperipheral="ADC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="ADC">
-              <edc:SFRFieldDef edc:cname="MUX" edc:desc="Analog Channel and Gain Selection Bits" edc:nzwidth="0x5">
+              <edc:SFRFieldDef edc:cname="MUX" edc:desc="ADC channel selection bits" edc:nzwidth="0x5">
                 <edc:SFRFieldSemantic edc:cname="ADC0" edc:desc="ADC input pin 0" edc:when="(field &amp; 0x1F) == 0x0"/>
                 <edc:SFRFieldSemantic edc:cname="ADC1" edc:desc="ADC input pin 1" edc:when="(field &amp; 0x1F) == 0x1"/>
                 <edc:SFRFieldSemantic edc:cname="ADC2" edc:desc="ADC input pin 2" edc:when="(field &amp; 0x1F) == 0x2"/>

--- a/dfp/edc/ATmega808.PIC
+++ b/dfp/edc/ATmega808.PIC
@@ -40,8 +40,8 @@
     <edc:Interrupt edc:cname="PIT" edc:desc="" edc:irq="4" ltx:memberofperipheral="RTC"/>
     <edc:Interrupt edc:cname="CCL" edc:desc="" edc:irq="5" ltx:memberofperipheral="CCL"/>
     <edc:Interrupt edc:cname="PORT" edc:desc="" edc:irq="6" ltx:memberofperipheral="PORTA"/>
-    <edc:Interrupt edc:cname="LUNF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="OVF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="LUNF" edc:desc="" edc:irq="7" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="HUNF" edc:desc="" edc:irq="8" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="CMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
@@ -215,12 +215,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -283,7 +278,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3C00" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3C00" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -498,7 +493,24 @@
             </edc:SFRMode>
           </edc:SFRModeList>
         </edc:SFRDef>
-        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x7"/>
+        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x3"/>
+        <edc:SFRDef edc:_addr="0x7C" edc:access="--nn-nnn" edc:cname="XOSC32KCTRLA" edc:impl="0x37" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="CLKCTRL">
+          <edc:SFRModeList>
+            <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="CLKCTRL">
+              <edc:SFRFieldDef edc:cname="ENABLE" edc:desc="Enable" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="RUNSTDBY" edc:desc="Run standby" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="SEL" edc:desc="Select" edc:nzwidth="0x1"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CSUT" edc:desc="Crystal startup time" edc:nzwidth="0x2">
+                <edc:SFRFieldSemantic edc:cname="1K" edc:desc="1k cycles" edc:when="(field &amp; 0x3) == 0x00"/>
+                <edc:SFRFieldSemantic edc:cname="16K" edc:desc="16k cycles" edc:when="(field &amp; 0x3) == 0x01"/>
+                <edc:SFRFieldSemantic edc:cname="32K" edc:desc="32k cycles" edc:when="(field &amp; 0x3) == 0x02"/>
+                <edc:SFRFieldSemantic edc:cname="64K" edc:desc="64k cycles" edc:when="(field &amp; 0x3) == 0x03"/>
+              </edc:SFRFieldDef>
+            </edc:SFRMode>
+          </edc:SFRModeList>
+        </edc:SFRDef>
+        <edc:AdjustPoint edc:_addr="0x7D" edc:offset="0x3"/>
         <edc:SFRDef edc:_addr="0x80" edc:access="---nnnnn" edc:cname="CTRLA" edc:impl="0x1F" edc:mclr="00000101" edc:nzwidth="0x8" edc:por="00000101" ltx:memberofperipheral="BOD">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
@@ -525,12 +537,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -715,11 +722,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -916,10 +924,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -968,10 +976,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1020,10 +1028,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1072,10 +1080,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1124,10 +1132,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1176,10 +1184,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/edc/ATmega809.PIC
+++ b/dfp/edc/ATmega809.PIC
@@ -47,8 +47,8 @@
     <edc:Interrupt edc:cname="CMP0" edc:desc="" edc:irq="9" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="CMP1" edc:desc="" edc:irq="10" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP1" edc:desc="" edc:irq="10" ltx:memberofperipheral="TCA0"/>
-    <edc:Interrupt edc:cname="CMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="LCMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
+    <edc:Interrupt edc:cname="CMP2" edc:desc="" edc:irq="11" ltx:memberofperipheral="TCA0"/>
     <edc:Interrupt edc:cname="INT" edc:desc="" edc:irq="12" ltx:memberofperipheral="TCB0"/>
     <edc:Interrupt edc:cname="INT" edc:desc="" edc:irq="13" ltx:memberofperipheral="TCB1"/>
     <edc:Interrupt edc:cname="TWIS" edc:desc="" edc:irq="14" ltx:memberofperipheral="TWI0"/>
@@ -221,12 +221,7 @@
               </edc:DCRFieldDef>
               <edc:DCRFieldDef edc:cname="LVL" edc:desc="BOD Level" edc:nzwidth="0x3">
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:DCRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:DCRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:DCRFieldDef>
             </edc:DCRMode>
@@ -289,7 +284,7 @@
         <edc:DCRDef edc:_addr="0x1287" edc:access="nnnnnnnn" edc:cname="APPEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
         <edc:DCRDef edc:_addr="0x1288" edc:access="nnnnnnnn" edc:cname="BOOTEND" edc:factorydefault="0x00" edc:impl="0x0" edc:nzwidth="0x8" edc:unused="0x0" edc:useinchecksum="0xFF" ltx:memberofperipheral="FUSE"/>
       </edc:ConfigFuseSector>
-      <edc:GPRDataSector edc:beginaddr="0x3C00" edc:endaddr="0x4000" edc:regionid="INTERNAL_SRAM"/>
+      <edc:GPRDataSector edc:beginaddr="0x3C00" edc:endaddr="0x4000" edc:isexecutable="false" edc:regionid="INTERNAL_SRAM"/>
       <edc:SFRDataSector edc:beginaddr="0x0" edc:endaddr="0x100A" edc:regionid="IO">
         <edc:SFRDef edc:_addr="0x0" edc:access="nnnnnnnn" edc:cname="DIR" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
         <edc:SFRDef edc:_addr="0x1" edc:access="nnnnnnnn" edc:cname="OUT" edc:nzwidth="0x8" ltx:memberofperipheral="VPORTA"/>
@@ -504,7 +499,24 @@
             </edc:SFRMode>
           </edc:SFRModeList>
         </edc:SFRDef>
-        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x7"/>
+        <edc:AdjustPoint edc:_addr="0x79" edc:offset="0x3"/>
+        <edc:SFRDef edc:_addr="0x7C" edc:access="--nn-nnn" edc:cname="XOSC32KCTRLA" edc:impl="0x37" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="CLKCTRL">
+          <edc:SFRModeList>
+            <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="CLKCTRL">
+              <edc:SFRFieldDef edc:cname="ENABLE" edc:desc="Enable" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="RUNSTDBY" edc:desc="Run standby" edc:nzwidth="0x1"/>
+              <edc:SFRFieldDef edc:cname="SEL" edc:desc="Select" edc:nzwidth="0x1"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CSUT" edc:desc="Crystal startup time" edc:nzwidth="0x2">
+                <edc:SFRFieldSemantic edc:cname="1K" edc:desc="1k cycles" edc:when="(field &amp; 0x3) == 0x00"/>
+                <edc:SFRFieldSemantic edc:cname="16K" edc:desc="16k cycles" edc:when="(field &amp; 0x3) == 0x01"/>
+                <edc:SFRFieldSemantic edc:cname="32K" edc:desc="32k cycles" edc:when="(field &amp; 0x3) == 0x02"/>
+                <edc:SFRFieldSemantic edc:cname="64K" edc:desc="64k cycles" edc:when="(field &amp; 0x3) == 0x03"/>
+              </edc:SFRFieldDef>
+            </edc:SFRMode>
+          </edc:SFRModeList>
+        </edc:SFRDef>
+        <edc:AdjustPoint edc:_addr="0x7D" edc:offset="0x3"/>
         <edc:SFRDef edc:_addr="0x80" edc:access="---nnnnn" edc:cname="CTRLA" edc:impl="0x1F" edc:mclr="00000101" edc:nzwidth="0x8" edc:por="00000101" ltx:memberofperipheral="BOD">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
@@ -531,12 +543,7 @@
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="BOD">
               <edc:SFRFieldDef edc:cname="LVL" edc:desc="Bod level" edc:nzwidth="0x3">
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL0" edc:desc="1.8 V" edc:when="(field &amp; 0x7) == 0x00"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL1" edc:desc="2.1 V" edc:when="(field &amp; 0x7) == 0x01"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL2" edc:desc="2.6 V" edc:when="(field &amp; 0x7) == 0x02"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL3" edc:desc="2.9 V" edc:when="(field &amp; 0x7) == 0x03"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL4" edc:desc="3.3 V" edc:when="(field &amp; 0x7) == 0x04"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL5" edc:desc="3.7 V" edc:when="(field &amp; 0x7) == 0x05"/>
-                <edc:SFRFieldSemantic edc:cname="BODLEVEL6" edc:desc="4.0 V" edc:when="(field &amp; 0x7) == 0x06"/>
                 <edc:SFRFieldSemantic edc:cname="BODLEVEL7" edc:desc="4.2 V" edc:when="(field &amp; 0x7) == 0x07"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
@@ -721,11 +728,12 @@
           </edc:SFRModeList>
         </edc:SFRDef>
         <edc:AdjustPoint edc:_addr="0x123" edc:offset="0x1D"/>
-        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnn--n" edc:cname="CTRLA" edc:impl="0xF9" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
+        <edc:SFRDef edc:_addr="0x140" edc:access="nnnnnn-n" edc:cname="CTRLA" edc:impl="0xFD" edc:mclr="00000000" edc:nzwidth="0x8" edc:por="00000000" ltx:memberofperipheral="RTC">
           <edc:SFRModeList>
             <edc:SFRMode edc:id="DS.0" ltx:memberofperipheral="RTC">
               <edc:SFRFieldDef edc:cname="RTCEN" edc:desc="Enable" edc:nzwidth="0x1"/>
-              <edc:AdjustPoint edc:offset="0x2"/>
+              <edc:AdjustPoint edc:offset="0x1"/>
+              <edc:SFRFieldDef edc:cname="CORREN" edc:desc="Correction enable" edc:nzwidth="0x1"/>
               <edc:SFRFieldDef edc:cname="PRESCALER" edc:desc="Prescaling Factor" edc:nzwidth="0x4">
                 <edc:SFRFieldSemantic edc:cname="DIV1" edc:desc="RTC Clock / 1" edc:when="(field &amp; 0xF) == 0x00"/>
                 <edc:SFRFieldSemantic edc:cname="DIV2" edc:desc="RTC Clock / 2" edc:when="(field &amp; 0xF) == 0x01"/>
@@ -922,10 +930,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -974,10 +982,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1026,10 +1034,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1078,10 +1086,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1130,10 +1138,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1182,10 +1190,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1234,10 +1242,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>
@@ -1286,10 +1294,10 @@
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP0" edc:desc="Timer/Counter A0 compare 0" edc:when="(field &amp; 0xFF) == 0x84"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP1" edc:desc="Timer/Counter A0 compare 1" edc:when="(field &amp; 0xFF) == 0x85"/>
                 <edc:SFRFieldSemantic edc:cname="TCA0_CMP2" edc:desc="Timer/Counter A0 compare 2" edc:when="(field &amp; 0xFF) == 0x86"/>
-                <edc:SFRFieldSemantic edc:cname="TCB0_CMP0" edc:desc="Timer/Counter B0 compare 0" edc:when="(field &amp; 0xFF) == 0xA0"/>
-                <edc:SFRFieldSemantic edc:cname="TCB1_CMP0" edc:desc="Timer/Counter B1 compare 0" edc:when="(field &amp; 0xFF) == 0xA2"/>
-                <edc:SFRFieldSemantic edc:cname="TCB2_CMP0" edc:desc="Timer/Counter B2 compare 0" edc:when="(field &amp; 0xFF) == 0xA4"/>
-                <edc:SFRFieldSemantic edc:cname="TCB3_CMP0" edc:desc="Timer/Counter B3 compare 0" edc:when="(field &amp; 0xFF) == 0xA6"/>
+                <edc:SFRFieldSemantic edc:cname="TCB0_CAPT" edc:desc="Timer/Counter B0 capture" edc:when="(field &amp; 0xFF) == 0xA0"/>
+                <edc:SFRFieldSemantic edc:cname="TCB1_CAPT" edc:desc="Timer/Counter B1 capture" edc:when="(field &amp; 0xFF) == 0xA2"/>
+                <edc:SFRFieldSemantic edc:cname="TCB2_CAPT" edc:desc="Timer/Counter B2 capture" edc:when="(field &amp; 0xFF) == 0xA4"/>
+                <edc:SFRFieldSemantic edc:cname="TCB3_CAPT" edc:desc="Timer/Counter B3 capture" edc:when="(field &amp; 0xFF) == 0xA6"/>
               </edc:SFRFieldDef>
             </edc:SFRMode>
           </edc:SFRModeList>

--- a/dfp/include/avr/iom1608.h
+++ b/dfp/include/avr/iom1608.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -608,7 +603,7 @@ typedef struct CLKCTRL_struct
     register8_t reserved_0x19;
     register8_t reserved_0x1A;
     register8_t reserved_0x1B;
-    register8_t reserved_0x1C;
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
     register8_t reserved_0x1D;
     register8_t reserved_0x1E;
     register8_t reserved_0x1F;
@@ -622,6 +617,15 @@ typedef enum CLKCTRL_CLKSEL_enum
     CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768kHz crystal oscillator */
     CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
 } CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4),  /* 64k cycles */
+} CLKCTRL_CSUT_t;
 
 /* Prescaler division select */
 typedef enum CLKCTRL_PDIV_enum
@@ -821,10 +825,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -893,12 +897,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -2205,6 +2204,7 @@ IO Module Instances. Mapped to memory.
 #define CLKCTRL_OSC20MCALIBA  _SFR_MEM8(0x0071)
 #define CLKCTRL_OSC20MCALIBB  _SFR_MEM8(0x0072)
 #define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
 
 
 /* BOD - Bod interface */
@@ -3327,6 +3327,19 @@ IO Module Instances. Mapped to memory.
 /* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
 /* CLKCTRL_RUNSTDBY  is already defined. */
 
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT1_bp  5  /* Crystal startup time bit 1 position. */
+
 /* CPU - CPU */
 /* CPU.CCP  bit masks and bit positions */
 #define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
@@ -3924,6 +3937,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */

--- a/dfp/include/avr/iom1609.h
+++ b/dfp/include/avr/iom1609.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -608,7 +603,7 @@ typedef struct CLKCTRL_struct
     register8_t reserved_0x19;
     register8_t reserved_0x1A;
     register8_t reserved_0x1B;
-    register8_t reserved_0x1C;
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
     register8_t reserved_0x1D;
     register8_t reserved_0x1E;
     register8_t reserved_0x1F;
@@ -622,6 +617,15 @@ typedef enum CLKCTRL_CLKSEL_enum
     CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768kHz crystal oscillator */
     CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
 } CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4),  /* 64k cycles */
+} CLKCTRL_CSUT_t;
 
 /* Prescaler division select */
 typedef enum CLKCTRL_PDIV_enum
@@ -823,10 +827,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -895,12 +899,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -2209,6 +2208,7 @@ IO Module Instances. Mapped to memory.
 #define CLKCTRL_OSC20MCALIBA  _SFR_MEM8(0x0071)
 #define CLKCTRL_OSC20MCALIBB  _SFR_MEM8(0x0072)
 #define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
 
 
 /* BOD - Bod interface */
@@ -3369,6 +3369,19 @@ IO Module Instances. Mapped to memory.
 /* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
 /* CLKCTRL_RUNSTDBY  is already defined. */
 
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT1_bp  5  /* Crystal startup time bit 1 position. */
+
 /* CPU - CPU */
 /* CPU.CCP  bit masks and bit positions */
 #define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
@@ -3972,6 +3985,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
@@ -4936,10 +4951,10 @@ IO Module Instances. Mapped to memory.
 #define PORTA_PORT_vect      _VECTOR(6)  /*  */
 
 /* TCA0 interrupt vectors */
-#define TCA0_OVF_vect_num  7
-#define TCA0_OVF_vect      _VECTOR(7)  /*  */
 #define TCA0_LUNF_vect_num  7
 #define TCA0_LUNF_vect      _VECTOR(7)  /*  */
+#define TCA0_OVF_vect_num  7
+#define TCA0_OVF_vect      _VECTOR(7)  /*  */
 #define TCA0_HUNF_vect_num  8
 #define TCA0_HUNF_vect      _VECTOR(8)  /*  */
 #define TCA0_LCMP0_vect_num  9

--- a/dfp/include/avr/iom3208.h
+++ b/dfp/include/avr/iom3208.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -830,10 +825,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -902,12 +897,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -3947,6 +3937,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */

--- a/dfp/include/avr/iom3209.h
+++ b/dfp/include/avr/iom3209.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -832,10 +827,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -904,12 +899,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -3995,6 +3985,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */

--- a/dfp/include/avr/iom4808.h
+++ b/dfp/include/avr/iom4808.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -830,10 +825,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -902,12 +897,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -3947,6 +3937,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
@@ -4911,24 +4903,24 @@ IO Module Instances. Mapped to memory.
 #define PORTA_PORT_vect      _VECTOR(6)  /*  */
 
 /* TCA0 interrupt vectors */
-#define TCA0_OVF_vect_num  7
-#define TCA0_OVF_vect      _VECTOR(7)  /*  */
 #define TCA0_LUNF_vect_num  7
 #define TCA0_LUNF_vect      _VECTOR(7)  /*  */
+#define TCA0_OVF_vect_num  7
+#define TCA0_OVF_vect      _VECTOR(7)  /*  */
 #define TCA0_HUNF_vect_num  8
 #define TCA0_HUNF_vect      _VECTOR(8)  /*  */
 #define TCA0_LCMP0_vect_num  9
 #define TCA0_LCMP0_vect      _VECTOR(9)  /*  */
 #define TCA0_CMP0_vect_num  9
 #define TCA0_CMP0_vect      _VECTOR(9)  /*  */
-#define TCA0_CMP1_vect_num  10
-#define TCA0_CMP1_vect      _VECTOR(10)  /*  */
 #define TCA0_LCMP1_vect_num  10
 #define TCA0_LCMP1_vect      _VECTOR(10)  /*  */
-#define TCA0_LCMP2_vect_num  11
-#define TCA0_LCMP2_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP1_vect_num  10
+#define TCA0_CMP1_vect      _VECTOR(10)  /*  */
 #define TCA0_CMP2_vect_num  11
 #define TCA0_CMP2_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP2_vect_num  11
+#define TCA0_LCMP2_vect      _VECTOR(11)  /*  */
 
 /* TCB0 interrupt vectors */
 #define TCB0_INT_vect_num  12

--- a/dfp/include/avr/iom4809.h
+++ b/dfp/include/avr/iom4809.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -832,10 +827,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -904,12 +899,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -3995,6 +3985,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */

--- a/dfp/include/avr/iom808.h
+++ b/dfp/include/avr/iom808.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -608,7 +603,7 @@ typedef struct CLKCTRL_struct
     register8_t reserved_0x19;
     register8_t reserved_0x1A;
     register8_t reserved_0x1B;
-    register8_t reserved_0x1C;
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
     register8_t reserved_0x1D;
     register8_t reserved_0x1E;
     register8_t reserved_0x1F;
@@ -622,6 +617,15 @@ typedef enum CLKCTRL_CLKSEL_enum
     CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768kHz crystal oscillator */
     CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
 } CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4),  /* 64k cycles */
+} CLKCTRL_CSUT_t;
 
 /* Prescaler division select */
 typedef enum CLKCTRL_PDIV_enum
@@ -821,10 +825,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -893,12 +897,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -2205,6 +2204,7 @@ IO Module Instances. Mapped to memory.
 #define CLKCTRL_OSC20MCALIBA  _SFR_MEM8(0x0071)
 #define CLKCTRL_OSC20MCALIBB  _SFR_MEM8(0x0072)
 #define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
 
 
 /* BOD - Bod interface */
@@ -3327,6 +3327,19 @@ IO Module Instances. Mapped to memory.
 /* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
 /* CLKCTRL_RUNSTDBY  is already defined. */
 
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT1_bp  5  /* Crystal startup time bit 1 position. */
+
 /* CPU - CPU */
 /* CPU.CCP  bit masks and bit positions */
 #define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
@@ -3924,6 +3937,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
@@ -4888,10 +4903,10 @@ IO Module Instances. Mapped to memory.
 #define PORTA_PORT_vect      _VECTOR(6)  /*  */
 
 /* TCA0 interrupt vectors */
-#define TCA0_LUNF_vect_num  7
-#define TCA0_LUNF_vect      _VECTOR(7)  /*  */
 #define TCA0_OVF_vect_num  7
 #define TCA0_OVF_vect      _VECTOR(7)  /*  */
+#define TCA0_LUNF_vect_num  7
+#define TCA0_LUNF_vect      _VECTOR(7)  /*  */
 #define TCA0_HUNF_vect_num  8
 #define TCA0_HUNF_vect      _VECTOR(8)  /*  */
 #define TCA0_LCMP0_vect_num  9

--- a/dfp/include/avr/iom809.h
+++ b/dfp/include/avr/iom809.h
@@ -327,12 +327,7 @@ typedef enum BOD_ACTIVE_enum
 typedef enum BOD_LVL_enum
 {
     BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* 1.8 V */
-    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 2.1 V */
     BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.6 V */
-    BOD_LVL_BODLEVEL3_gc = (0x03<<0),  /* 2.9 V */
-    BOD_LVL_BODLEVEL4_gc = (0x04<<0),  /* 3.3 V */
-    BOD_LVL_BODLEVEL5_gc = (0x05<<0),  /* 3.7 V */
-    BOD_LVL_BODLEVEL6_gc = (0x06<<0),  /* 4.0 V */
     BOD_LVL_BODLEVEL7_gc = (0x07<<0),  /* 4.2 V */
 } BOD_LVL_t;
 
@@ -608,7 +603,7 @@ typedef struct CLKCTRL_struct
     register8_t reserved_0x19;
     register8_t reserved_0x1A;
     register8_t reserved_0x1B;
-    register8_t reserved_0x1C;
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
     register8_t reserved_0x1D;
     register8_t reserved_0x1E;
     register8_t reserved_0x1F;
@@ -622,6 +617,15 @@ typedef enum CLKCTRL_CLKSEL_enum
     CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768kHz crystal oscillator */
     CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
 } CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4),  /* 64k cycles */
+} CLKCTRL_CSUT_t;
 
 /* Prescaler division select */
 typedef enum CLKCTRL_PDIV_enum
@@ -823,10 +827,10 @@ typedef enum EVSYS_GENERATOR_enum
     EVSYS_GENERATOR_TCA0_CMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 */
     EVSYS_GENERATOR_TCA0_CMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 */
     EVSYS_GENERATOR_TCA0_CMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 */
-    EVSYS_GENERATOR_TCB0_CMP0_gc = (0xA0<<0),  /* Timer/Counter B0 compare 0 */
-    EVSYS_GENERATOR_TCB1_CMP0_gc = (0xA2<<0),  /* Timer/Counter B1 compare 0 */
-    EVSYS_GENERATOR_TCB2_CMP0_gc = (0xA4<<0),  /* Timer/Counter B2 compare 0 */
-    EVSYS_GENERATOR_TCB3_CMP0_gc = (0xA6<<0),  /* Timer/Counter B3 compare 0 */
+    EVSYS_GENERATOR_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_GENERATOR_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_GENERATOR_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_GENERATOR_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
 } EVSYS_GENERATOR_t;
 
 /* Software event on channels select */
@@ -895,12 +899,7 @@ typedef enum FREQSEL_enum
 typedef enum LVL_enum
 {
     LVL_BODLEVEL0_gc = (0x00<<5),  /* 1.8 V */
-    LVL_BODLEVEL1_gc = (0x01<<5),  /* 2.1 V */
     LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.6 V */
-    LVL_BODLEVEL3_gc = (0x03<<5),  /* 2.9 V */
-    LVL_BODLEVEL4_gc = (0x04<<5),  /* 3.3 V */
-    LVL_BODLEVEL5_gc = (0x05<<5),  /* 3.7 V */
-    LVL_BODLEVEL6_gc = (0x06<<5),  /* 4.0 V */
     LVL_BODLEVEL7_gc = (0x07<<5),  /* 4.2 V */
 } LVL_t;
 
@@ -2209,6 +2208,7 @@ IO Module Instances. Mapped to memory.
 #define CLKCTRL_OSC20MCALIBA  _SFR_MEM8(0x0071)
 #define CLKCTRL_OSC20MCALIBB  _SFR_MEM8(0x0072)
 #define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
 
 
 /* BOD - Bod interface */
@@ -3369,6 +3369,19 @@ IO Module Instances. Mapped to memory.
 /* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
 /* CLKCTRL_RUNSTDBY  is already defined. */
 
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT1_bp  5  /* Crystal startup time bit 1 position. */
+
 /* CPU - CPU */
 /* CPU.CCP  bit masks and bit positions */
 #define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
@@ -3972,6 +3985,8 @@ IO Module Instances. Mapped to memory.
 /* RTC.CTRLA  bit masks and bit positions */
 #define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
 #define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
 #define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
 #define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
 #define RTC_PRESCALER0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
@@ -4950,10 +4965,10 @@ IO Module Instances. Mapped to memory.
 #define TCA0_CMP1_vect      _VECTOR(10)  /*  */
 #define TCA0_LCMP1_vect_num  10
 #define TCA0_LCMP1_vect      _VECTOR(10)  /*  */
-#define TCA0_CMP2_vect_num  11
-#define TCA0_CMP2_vect      _VECTOR(11)  /*  */
 #define TCA0_LCMP2_vect_num  11
 #define TCA0_LCMP2_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  11
+#define TCA0_CMP2_vect      _VECTOR(11)  /*  */
 
 /* TCB0 interrupt vectors */
 #define TCB0_INT_vect_num  12

--- a/dfp/include/component-version.h
+++ b/dfp/include/component-version.h
@@ -43,7 +43,7 @@
 // The build number does not refer to the component, but to the build number
 // of the device pack that provides the component.
 //
-#define BUILD_NUMBER 2
+#define BUILD_NUMBER 12
 
 //
 // The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
@@ -58,7 +58,7 @@
 //     "%Y-%m-%d %H:%M:%S"
 //
 //
-#define COMPONENT_DATE_STRING "2019-01-24 03:52:34"
+#define COMPONENT_DATE_STRING "2019-04-26 00:07:32"
 
 #endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
 

--- a/dfp/package.content
+++ b/dfp/package.content
@@ -6786,7 +6786,8 @@
   </content>
   <pdsc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" vendor="Microchip" compliant="false">
 		<releases>
-			<release version="2.0.BUILDNUMBER">Succeeds Atmel.ATmega_DFP 1.3.300.</release>
+			<release version="2.0.BUILDNUMBER">Added missing registers and corrceted event generator list for mega4809/4808/3209/3208/1609/1608/809/808.</release>
+			<release version="2.0.2" date="2019-01-24">Succeeds Atmel.ATmega_DFP 1.3.300.</release>
 		</releases>
 	</pdsc>
 </package>


### PR DESCRIPTION
Resolves #3 (Add version 2.0.12 (2019-04-26)).

Added missing registers and corrected event generator list for mega4809/4808/3209/3208/1609/1608/809/808.